### PR TITLE
Updates google_publish to use a Service Account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 db.sqlite3
+.env
 google-service-account.json
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 db.sqlite3
+google-service-account.json
 __pycache__

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ to publish events on your behalf.
 1. Create a [Service Account](https://console.developers.google.com/iam-admin/serviceaccounts/create)
    for the project. Don't set any roles, they are not necessary.
 1. Create a (JSON) key for the Service Account and save the JSON file. Treat
-   this file as a secret, please don't commit it to GitHub.
+   this file as a secret, please don't commit it to GitHub. Save it to the
+   project root as `google-service-account.json`. You can save it to an
+   alternative location and set the `GOOGLE_SERVICE_ACCOUNT` environment
+   variable to the alternate path.
 1. Enable the [Calendar API](https://console.developers.google.com/apis/api/calendar-json.googleapis.com/overview)
    for the API Project you just created.
 1. Create a [Google Calendar](https://calendar.google.com/calendar/r/settings)
@@ -42,11 +45,26 @@ to publish events on your behalf.
    find your Service Account's email address in the [IAM
    Admin](https://console.developers.google.com/iam-admin/serviceaccounts).
    Allow the Service Account to "Make changes to events" for your calendar.
+ 1. Copy the Calendar Id from the settings in Google Calendar and set the
+    environment variable `GOOGLE_CALENDAR_ID`.
 
 
 ### Create calendar events
 
 [Create an event](http://localhost:8000/admin/census/event/add/).
+
+
+### Environment variables
+
+For development, you can set these in `.env` and pipenv will load them
+automatically.
+
+Variable | Description | Default
+-------- | ----------- | -------
+`GOOGLE_CALENDAR_ID` | The Google Calendar Id where events will be published. |
+`GOOGLE_SERVICE_ACCOUNT` | The local path to your Service Account JSON credentials. | `./google-service-account.json`
+`LOG_LEVEL` | Logging verbosity. | `INFO`
+`TIME_ZONE` | Set the server TZ to your local timezone.  | `America/Los_Angeles`
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -7,12 +7,42 @@ Find census events and resources near you.
 
 - Events and resources
 - Partners can enter event information through forms
-- Events are published to google calendar
+- Events are published to Google Calendar
 - Export events via CSV
 - Integrate with SwORD via CSV export
 
+Instead of re-creating a calendar tool, we're leveraging a fantastic and proven
+one: Google Calendar.
+
 
 ## Usage
+
+Census Events creates a publishing workflow around Google Calendar. Currently,
+the publishing is one-way, from Census Events to Google Calendar.
+
+
+### Setup Google Calendar
+
+Census Events will publish events to Google Calendar. You need to create
+a Calendar as well as a [Service
+Account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount),
+to publish events on your behalf.
+
+1. Make sure you are logged into Google with your G Suite account (you can also
+   use your personal account if you don't have a G Suite organization).
+1. Create a new [Google API Project](https://console.developers.google.com/apis/credentials).
+1. Create a [Service Account](https://console.developers.google.com/iam-admin/serviceaccounts/create)
+   for the project. Don't set any roles, they are not necessary.
+1. Create a (JSON) key for the Service Account and save the JSON file. Treat
+   this file as a secret, please don't commit it to GitHub.
+1. Enable the [Calendar API](https://console.developers.google.com/apis/api/calendar-json.googleapis.com/overview)
+   for the API Project you just created.
+1. Create a [Google Calendar](https://calendar.google.com/calendar/r/settings)
+   and share the calendar with your Service Account's email address. You can
+   find your Service Account's email address in the [IAM
+   Admin](https://console.developers.google.com/iam-admin/serviceaccounts).
+   Allow the Service Account to "Make changes to events" for your calendar.
+
 
 ### Create calendar events
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ to publish events on your behalf.
 
 1. Make sure you are logged into Google with your G Suite account (you can also
    use your personal account if you don't have a G Suite organization).
-1. Create a new [Google API Project](https://console.developers.google.com/apis/credentials).
+1. Create a new [Google API
+   Project](https://console.developers.google.com/apis/credentials). Click on
+   "My Project" at the top of the page to create a new project.
 1. Create a [Service Account](https://console.developers.google.com/iam-admin/serviceaccounts/create)
    for the project. Don't set any roles, they are not necessary.
 1. Create a (JSON) key for the Service Account and save the JSON file. Treat
@@ -44,9 +46,13 @@ to publish events on your behalf.
    and share the calendar with your Service Account's email address. You can
    find your Service Account's email address in the [IAM
    Admin](https://console.developers.google.com/iam-admin/serviceaccounts).
-   Allow the Service Account to "Make changes to events" for your calendar.
- 1. Copy the Calendar Id from the settings in Google Calendar and set the
-    environment variable `GOOGLE_CALENDAR_ID`.
+   Allow the Service Account to "Make changes to events" to your calendar. To
+   access sharing settings, open your [Google Calendar
+   settings](https://calendar.google.com/calendar/r/settings) and then click the
+   calendar you just created from the left navigation under "Settings for my
+   calendars".
+1. Copy the Calendar Id from the settings in Google Calendar and set the
+   environment variable `GOOGLE_CALENDAR_ID`.
 
 
 ### Create calendar events

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Variable | Description | Default
 
 ### Prerequisites
 
-- Python 3
+- Python 3.6
 - pipenv
 
 We assume you are installing to a python virtualenv using pipenv.

--- a/census/google_calendar.py
+++ b/census/google_calendar.py
@@ -4,8 +4,7 @@ import os.path
 
 from django.conf import settings
 from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
+from google.oauth2 import service_account
 
 from . import constants
 from . import models
@@ -39,26 +38,10 @@ def google_publish_event(event):
       #}
     }
 
-    creds = None
-    # The file token.pickle stores the user's access and refresh tokens, and is
-    # created automatically when the authorization flow completes for the first
-    # time.
-    if os.path.exists('token.pickle'):
-        with open('token.pickle', 'rb') as token:
-            creds = pickle.load(token)
-    # If there are no (valid) credentials available, let the user log in.
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(
-                'credentials.json', SCOPES)
-            creds = flow.run_local_server()
-        # Save the credentials for the next run
-        with open('token.pickle', 'wb') as token:
-            pickle.dump(creds, token)
+    credentials = service_account.Credentials.from_service_account_file(
+        settings.GOOGLE_SERVICE_ACCOUNT, scopes=SCOPES)
 
-    service = build('calendar', 'v3', credentials=creds)
+    service = build('calendar', 'v3', credentials=credentials)
 
     result = service.events().insert(calendarId=settings.GOOGLE_CALENDAR_ID, body=payload).execute()
     print ('Event created: %s' % (result.get('htmlLink')))

--- a/census/google_calendar.py
+++ b/census/google_calendar.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import logging
 import pickle
 import os.path
 
@@ -9,6 +10,7 @@ from google.oauth2 import service_account
 from . import constants
 from . import models
 
+log = logging.getLogger(__name__)
 
 # If modifying these scopes, delete the file token.pickle.
 SCOPES = ['https://www.googleapis.com/auth/calendar']
@@ -40,11 +42,13 @@ def google_publish_event(event):
 
     credentials = service_account.Credentials.from_service_account_file(
         settings.GOOGLE_SERVICE_ACCOUNT, scopes=SCOPES)
-
     service = build('calendar', 'v3', credentials=credentials)
 
+    log.debug('event insert calendar=%s payload=%s', settings.GOOGLE_CALENDAR_ID, payload)
+    log.info('event insert event=%s title=%s', event.id, event.title)
     result = service.events().insert(calendarId=settings.GOOGLE_CALENDAR_ID, body=payload).execute()
-    print ('Event created: %s' % (result.get('htmlLink')))
 
+    log.debug('google event result=%s', result)
+    log.info('google event created id=%s url=%s', result.get('id'), result.get('htmlLink'))
     google_event = models.GoogleEvent(event=event, google_calendar_id=result['id'], published = datetime.now(tz=timezone.utc))
     google_event.save()

--- a/census/google_calendar.py
+++ b/census/google_calendar.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 import pickle
 import os.path
 
@@ -46,5 +46,5 @@ def google_publish_event(event):
     result = service.events().insert(calendarId=settings.GOOGLE_CALENDAR_ID, body=payload).execute()
     print ('Event created: %s' % (result.get('htmlLink')))
 
-    google_event = models.GoogleEvent(event=event, google_calendar_id=result['id'], published = datetime.datetime.now())
+    google_event = models.GoogleEvent(event=event, google_calendar_id=result['id'], published = datetime.now(tz=timezone.utc))
     google_event.save()

--- a/census/management/commands/google_publish.py
+++ b/census/management/commands/google_publish.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand, CommandError
 from census.models import Event, GoogleEvent
 from census.google_calendar import google_publish_event
 
+log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -14,6 +15,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # TODO optimize the SQL query
+        log.info('starting publish...')
         for event in Event.objects.all():
             try:
                 event.google_event
@@ -22,19 +24,8 @@ class Command(BaseCommand):
                 pass
             else:
                 # GoogleEvent exists, so it's already published. We should skip.
+                log.debug('event already published event=%s', event.id)
                 continue
 
+            log.info('event not yet published event=%s', event.id)
             google_publish_event(event)
-
-            #google_event = None
-            #try:
-            #    google_event = GoogleEvent.objects.get(event=event)
-            #except ObjectDoesNotExist:
-            #    # This is okay, the GoogleEvent will be created when published.
-            #    pass
-
-            #if google_event:
-            #    # Already published, skip
-            #    continue
-
-            #google_publish_event(event)

--- a/census/settings.py
+++ b/census/settings.py
@@ -107,7 +107,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = os.environ.get('TIME_ZONE', 'America/Los_Angeles')
 
 USE_I18N = True
 

--- a/census/settings.py
+++ b/census/settings.py
@@ -122,4 +122,8 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = 'static/'
 
-GOOGLE_CALENDAR_ID = os.environ.get('GOOGLE_CALENDAR_ID', 'openoakland.org_vbrd0poc6su2f6a0notsiu4qr8@group.calendar.google.com');
+# The Id of the calendar to which events will be published.
+GOOGLE_CALENDAR_ID = os.environ.get('GOOGLE_CALENDAR_ID', 'openoakland.org_vbrd0poc6su2f6a0notsiu4qr8@group.calendar.google.com')
+
+# Path to the Google Service Account with read/write access to the Google Calendar.
+GOOGLE_SERVICE_ACCOUNT = os.environ.get('GOOGLE_SERVICE_ACCOUNT', './google-service-account.json')

--- a/census/settings.py
+++ b/census/settings.py
@@ -115,6 +115,32 @@ USE_L10N = True
 
 USE_TZ = True
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'default',
+        },
+    },
+    'formatters': {
+        'default': {
+            'format': '{asctime} [{name}] {levelname} {message}',
+            'style': '{',
+        },
+    },
+    'loggers': {
+        'census': {
+            'handlers': ['console'],
+            'level': os.getenv('LOG_LEVEL', 'INFO'),
+        },
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
+    },
+}
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,4 @@
+# Fill out these values and save it as .env
+# Make sure not to commit any secrets to GitHub.
+GOOGLE_CALENDAR_ID=
+TIME_ZONE=America/Los_Angeles


### PR DESCRIPTION
Use a [Service Account](https://cloud.google.com/iam/docs/service-accounts) instead of a user application. This changes how the authentication works with the API. We won't get the OAuth screen when running publish via the command line anymore.

I tried to include all the instructions to setup from scratch. Creating the Google API Project, the Service Account, the Calendar, and how to share the calendar with the Service Account. For development, folks could create their own accounts and calendar, or we could create a shared dev account so people can get started quickly.

@mikeubell want to try out the setup and let me know if you run into trouble?