### PR TITLE
Export CSV with header

### DIFF
--- a/census/views.py
+++ b/census/views.py
@@ -1,20 +1,11 @@
 import csv
+import io
 
 from django.forms.models import model_to_dict
 from django.http import StreamingHttpResponse
 from django.shortcuts import render
 
 from . import models
-
-
-# https://docs.djangoproject.com/en/2.2/howto/outputting-csv/#streaming-csv-files
-class Echo:
-    """An object that implements just the write method of the file-like
-    interface.
-    """
-    def write(self, value):
-        """Write the value by returning it, instead of storing in a buffer."""
-        return value
 
 
 def export_events(request):
@@ -31,13 +22,27 @@ def export_events(request):
         'description',
     ]
 
-    print(models.Event)
     events = models.Event.objects.all()
-    pseudo_buffer = Echo()
-    writer = csv.DictWriter(pseudo_buffer, fieldnames=fields, dialect='excel')
-    response = StreamingHttpResponse((writer.writerow(model_to_dict(event, fields=fields)) for event in events),
-                                     content_type="text/csv")
+    csv_buffer = io.StringIO()
+    writer = csv.DictWriter(csv_buffer, fieldnames=fields, dialect='excel')
 
+    # Create a generator that writes to an in-memory CSV buffer in rows of 1000
+    # at a time. This allows us to stream a very large number of events to the
+    # browser.
+    def events_of(size=1000):
+        writer.writeheader()
+        i = 0
+        for event in events:
+            writer.writerow(model_to_dict(event, fields=fields))
+            if i % size == (size - 1):
+                yield csv_buffer.getvalue()
+                csv_buffer.truncate(0)
+                csv_buffer.seek(0)
+            i += 1
+
+        yield csv_buffer.getvalue()
+
+    response = StreamingHttpResponse(events_of(), content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="census_events.csv"'
     return response
 


### PR DESCRIPTION
We were missing the CSV header that defines the columns.

writeheader() doesn't return the return value of write(), so the Echo trick
doesn't work. Creating a one-off generator seemed a reasonable solution while
still being able to stream a large number of events.