### PR TITLE
Don't display long and lat for event entry.

### DIFF
--- a/census/forms.py
+++ b/census/forms.py
@@ -10,5 +10,5 @@ class EventForm(ModelForm):
                 'start_time': forms.TimeInput(attrs={'type': 'time'}),
                 'end_time': forms.TimeInput(attrs={'type': 'time'})
         }
-        exclude = ['approval_status']
+        exclude = ['approval_status', 'lon', 'lat']
 


### PR DESCRIPTION
I don't think users should input longitude and latitude when registering an event.