### PR TITLE
Fix bug when no recurrence

### DIFF
--- a/census/models.py
+++ b/census/models.py
@@ -20,7 +20,10 @@ class Event(models.Model):
         return self.title
 
     def first_date(self):
-        return self.recurrences.occurrences()[0].date()
+        try:
+            return self.recurrences.occurrences()[0].date()
+        except IndexError:
+            return None
 
     title = models.CharField(max_length=100, help_text="Title or short description of the event")
     description = models.TextField(blank=True, help_text="Full description of the event")

--- a/census/tests/test_models.py
+++ b/census/tests/test_models.py
@@ -1,0 +1,21 @@
+from datetime import date
+
+from django.test import TestCase
+
+from census.models import Event
+
+class EventTest(TestCase):
+    fixtures=["census/fixtures/events.json"]
+    def setUp(self):
+        # Get an event that has recurrences
+        self.event = [event for event in Event.objects.all() if event.recurrences.rrules][0]
+
+    def test_first_date(self):
+        first_date = self.event.first_date()
+        self.assertIsInstance(first_date, date)
+
+        self.event.recurrences.rrules = []
+        self.event.save()
+
+        first_date = self.event.first_date()
+        self.assertIs(first_date, None)


### PR DESCRIPTION
When an event has no recurrence, the first_date function would throw an
IndexError. To fix this, the function now returns None instead.