### PR TITLE
Polish Styling on New Event Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ google-service-account.json
 __pycache__
 *.DS_Store
 staticfiles
-.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ google-service-account.json
 __pycache__
 *.DS_Store
 staticfiles
+.vscode/*

--- a/census/static/census/app.css
+++ b/census/static/census/app.css
@@ -10,17 +10,11 @@ body {
   text-align: center;
 }
 
-.section-card {
-  max-width: 72ex;
-  margin-bottom: 1rem;
-  margin-top: 1rem;
-  padding: 1rem;
-  font-size: 1rem;
-  line-height: 1.6;
+.section-card, .preview {
   background-color: #fff;
   border: 1px solid #f0f0f0;
 }
 
-.checkbox-wrapper {
-  margin-top: 2em;
+.recurrence-widget {
+  display: inline-block;
 }

--- a/census/templates/event.html
+++ b/census/templates/event.html
@@ -7,99 +7,116 @@
 <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 
 <div class="grid-container">
-  <section class='site-component-section section-card'>
-    <div class='preview usa-prose site-prose '>
-      {{ form.errors }}
-      <form action="/submit/" method="post" class="usa-form">
-        <fieldset class="usa-fieldset">
-          <legend class="usa-legend">New Event</legend>
+    <div class="grid-row">
+        <section class='tablet:grid-col-8 tablet:grid-offset-2 section-card padding-x-4 padding-y-2 margin-4'>
+            {{ form.errors }}
+            <form action="/submit/" method="post" class="">
+                <fieldset class="usa-fieldset">
+                    <legend class="usa-legend">New Event</legend>
+                    {% csrf_token %}
+                    {{ form.media }}
+                    <div>
+                      <label class="usa-label" for="{{ form.title.id_for_label }}">Title:</label>  
+                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.title.help_text}}</span>            
+                      <input type="text" name="title" maxlength="100" class="usa-input" required="" id="{{ form.title.id_for_label }}">
+                    </div>
+                    <div>
+                      <label class="usa-label" for="{{ form.description.id_for_label }}">Description:</label>
+                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.description.help_text}}</span>
+                      <textarea name="description" cols="40" rows="10" class="usa-textarea" id="{{ form.description.id_for_label }}"></textarea>              
+                    </div>
+                    <div>
+                        <label class="usa-label" for="{{form.organization_name.id_for_label}}">Organization name:</label>
+                        <span class="usa-hint line-height-body-1 font-body-2xs">{{form.organization_name.help_text}}</span>
+                        <input type="text" name="organization_name" maxlength="100" class="usa-input" required="" id="{{form.organization_name.id_for_label}}">
+                    </div>  
+                    <div>
+                      <label class="usa-label" for="{{form.location.id_for_label}}">Location:</label>
+                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.organization_name.help_text}}</span>
+                      <input type="text" name="location" maxlength="100" class="usa-input" required="" id="{{form.organization_name.id_for_label}}">
+                    </div>
+                    <div>
+                      <label class="usa-label" for="{{ form.contact_name.id_for_label }}">Contact Name:</label>  
+                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_name.help_text}}</span>            
+                      <input type="text" name="title" maxlength="100" class="usa-input" required="" id="{{ form.contact_name.id_for_label }}">  
+                    </div>
+                    <div>
+                      <label class="usa-label" for="{{ form.contact_email.id_for_label }}">Contact Email:</label>  
+                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_email.help_text}}</span>            
+                      <input type="email" name="title" maxlength="100" class="usa-input" required="" id="{{ form.contact_email.id_for_label }}">
+                    </div>
+                    <div>
+                      <label class="usa-label" for="{{ form.contact_phone.id_for_label }}">Contact Phone:</label>  
+                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_phone.help_text}}</span>            
+                      <input type="tel" name="title" maxlength="100" class="usa-input" required="" id="{{ form.contact_phone.id_for_label }}">
+                    </div>  
+  
+                    <div>
+                      <label class="usa-label" for="{{form.event_type.id_for_label}}">Event type:</label>
+                      <select name="event_type" class="usa-input desktop:grid-col-3 grid-col-6" required="" id="{{form.event_type.id_for_label}}">
+                          {% for value, display in form.fields.event_type.choices %}
+                            <option value="{{ value }}"{% if form.fields.event_type.value == value %} selected{% endif %}>{{ display }}</option>
+                          {% endfor %}
+                      </select>
+                    </div>
 
-          {% csrf_token %}
-          {{ form.media }}
-          <div>
-            <label class="usa-label" for="{{ form.title.id_for_label }}">Title:</label>  
-            <span class="usa-hint line-height-body-1 font-body-2xs">{{form.title.help_text}}</span>            
-            <input type="text" name="title" maxlength="100" class="usa-input" required="" id="{{ form.title.id_for_label }}">
-          </div>
+                    <div class="checkbox-wrapper">
+                        <div class="usa-label grid-col-12">Census Equipment:</div>
+                        <div class="usa-hint font-body-2xs margin-y-1">{{form.is_census_equipped.help_text}}</div>
+                        <div class="usa-checkbox">
+                          <input 
+                            class="usa-checkbox__input" 
+                            id="{{form.is_census_equipped.id_for_label}}"
+                            type="checkbox"
+                            name="is_census_equipped"
+                            value="is_census_equipped"
+                            >
+                          <label class="usa-checkbox__label" for="{{form.is_census_equipped.id_for_label}}">Is census equipped?</label>
+                        </div>
+                    </div>
+                    <div class="checkbox-wrapper grid-row">
+                        <div class="usa-label grid-col-12 margin-bottom-2">{{form.languages.help_text}}</div>
+                        {% for value, name in form.languages.field.choices %}
+                        <div class="usa-checkbox grid-col-6">
+                            <input
+                              class="usa-checkbox__input"
+                              id="{{form.languages.id_for_label}}_{{ forloop.counter }}"
+                              type="checkbox"
+                              name="{{ form.languages.name }}"
+                              value="{{ value }}"
+                              {% if value in form.languages.value %}
+                              checked="checked"
+                              {% endif %}
+                              >
+                              <label class="usa-checkbox__label" for="{{form.languages.id_for_label}}_{{ forloop.counter }}">{{ name }}</label>
+                        </div>
+                        {% endfor %} 
+                    </div>
 
-          <div>
-            <label class="usa-label" for="{{ form.description.id_for_label }}">Description:</label>
-            <span class="usa-hint line-height-body-1 font-body-2xs">{{form.description.help_text}}</span>
-            <textarea name="description" cols="40" rows="10" class="usa-textarea" id="{{ form.description.id_for_label }}"></textarea>              
-          </div>
-
-          <label class="usa-label" for="{{form.organization_name.id_for_label}}">Organization name:</label>
-          <span class="usa-hint line-height-body-1 font-body-2xs">{{form.organization_name.help_text}}</span>
-          <input type="text" name="organization_name" maxlength="100" class="usa-input" required="" id="{{form.organization_name.id_for_label}}">
-
-          <div>
-              <label class="usa-label" for="{{form.location.id_for_label}}">Location:</label>
-              <span class="usa-hint line-height-body-1 font-body-2xs">{{form.organization_name.help_text}}</span>
-              <input type="text" name="location" maxlength="100" class="usa-input" required="" id="{{form.organization_name.id_for_label}}">
-          </div>
-
-          <label class="usa-label" for="{{form.event_type.id_for_label}}">Event type:</label>
-          <select name="event_type" class="usa-input" required="" id="{{form.event_type.id_for_label}}">
-              {% for value, display in form.fields.event_type.choices %}
-                <option value="{{ value }}"{% if form.fields.event_type.value == value %} selected{% endif %}>{{ display }}</option>
-              {% endfor %}
-          </select>
-
-          <div class="checkbox-wrapper">
-            <div class="usa-checkbox">
-                <input 
-                  class="usa-checkbox__input" 
-                  id="{{form.is_census_equipped.id_for_label}}"
-                  type="checkbox"
-                  name="is_census_equipped"
-                  value="is_census_equipped"
-                  >
-                <label class="usa-checkbox__label" for="{{form.is_census_equipped.id_for_label}}">Is census equipped?</label>
-                <span class="usa-hint line-height-body-1 font-body-2xs">{{form.is_census_equipped.help_text}}</span>
-            </div>
-          </div>
-
-          <div class="checkbox-wrapper">
-            {% for value, name in form.languages.field.choices %}
-            <div class="usa-checkbox">
-                <input
-                  class="usa-checkbox__input"
-                  id="{{form.languages.id_for_label}}_{{ forloop.counter }}"
-                  type="checkbox"
-                  name="{{ form.languages.name }}"
-                  value="{{ value }}"
-                  {% if value in form.languages.value %}
-                  checked="checked"
-                  {% endif %}
-                  >
-                  <label class="usa-checkbox__label" for="{{form.languages.id_for_label}}_{{ forloop.counter }}">{{ name }}</label>
-            </div>
-            {% endfor %}
-            <span class="usa-hint line-height-body-1 font-body-2xs">{{form.languages.help_text}}</span>
-          </div>
-
-          <label class="usa-label" for="{{form.start_datetime.id_for_label}}">Event start:</label>
-          <span class="usa-hint line-height-body-1 font-body-2xs">{{form.start_datetime.help_text}}</span>
-          <input type="text" name="start_datetime" required="" id="{{form.start_datetime.id_for_label}}" value="{{form.start_datetime.value | date:'Y-m-d H:i'}}">
-
-          <label class="usa-label" for="{{form.end_datetime.id_for_label}}">Event end:</label>
-          <span class="usa-hint line-height-body-1 font-body-2xs">{{form.end_datetime.help_text}}</span>
-          <input type="text" name="end_datetime" required="" id="{{form.end_datetime.id_for_label}}" value="{{form.end_datetime.value | date:'Y-m-d H:i'}}">
-
-          {% if enable_recurrence %}
-          <label class="usa-label" for="{{ form.recurrences.id_for_label }}">Recurrences:</label>
-          <span class="usa-hint line-height-body-1 font-body-2xs">{{ form.recurrences.help_text }}</span>
-          {{ form.recurrences }}
-          {% else %}
-          <input type="hidden" name="recurrences" value="" />
-          {% endif %}
-
-          </br>
-          <input type="submit" value="Submit" class="usa-button">
-        </fieldset>
-      </form>
+                    <div>
+                        <label class="usa-label" for="{{form.start_datetime.id_for_label}}">Event start:</label>
+                        <div class="usa-hint line-height-body-1 font-body-2xs">{{form.start_datetime.help_text}}</div>
+                        <input class="usa-input desktop:grid-col-3 grid-col-6" type="text" name="start_datetime" required="" id="{{form.start_datetime.id_for_label}}" value="{{form.start_datetime.value | date:'Y-m-d H:i'}}">
+                    </div>
+                    <div>
+                        <label class="usa-label" for="{{form.end_datetime.id_for_label}}">Event end:</label>
+                        <div class="usa-hint line-height-body-1 font-body-2xs">{{form.end_datetime.help_text}}</div>
+                        <input class="usa-input desktop:grid-col-3 grid-col-6" type="text" name="end_datetime" required="" id="{{form.end_datetime.id_for_label}}" value="{{form.end_datetime.value | date:'Y-m-d H:i'}}">
+                    </div>          
+                    {% if enable_recurrence %}
+                    <span class="usa-hint line-height-body-1 font-body-2xs">{{ form.recurrences.help_text }}</span>
+                    <div class="grid-row">
+                        {{ form.recurrences }}
+                    </div>
+                    {% else %}
+                    <input type="hidden" name="recurrences" value="" />
+                    {% endif %}
+                    </br>
+                    <input type="submit" value="Submit" class="usa-button">
+                </fieldset>
+            </form>
+        </section>
     </div>
-  </section>
 </div>
 
 {% endblock content %}


### PR DESCRIPTION
## Overview:
Changes here are only cosmetic:
1. Center form using USWS grid and make fields a bit more responsive
1. Removed some specific css styling and using [USWDS utility classes instead](https://designsystem.digital.gov/utilities/)
1. Standardize tab spacing to 4 spaces in entire form

Next steps will be to break out into re-usable template for New and Edit pages but I want to avoid more merge conflicts so would rater get this piece in first.

---

**Screenshots Before:**
<img width="1208" alt="Screen Shot 2019-11-17 at 11 21 45 AM" src="https://user-images.githubusercontent.com/933822/69012664-0fb63880-092d-11ea-8cf3-1c275a305d25.png">
<img width="1245" alt="Screen Shot 2019-11-17 at 11 22 13 AM" src="https://user-images.githubusercontent.com/933822/69012666-147aec80-092d-11ea-8260-c2185adb9100.png">


**Screenshots After**
<img width="1236" alt="Screen Shot 2019-11-17 at 11 21 54 AM" src="https://user-images.githubusercontent.com/933822/69012670-1fce1800-092d-11ea-825a-0b8fcf55fff1.png">
<img width="1231" alt="Screen Shot 2019-11-17 at 11 22 05 AM" src="https://user-images.githubusercontent.com/933822/69012672-23619f00-092d-11ea-9797-f5ff077695b6.png">
