### PR TITLE
Delete Page styling

### DIFF
--- a/census/templates/census/event_confirm_delete.html
+++ b/census/templates/census/event_confirm_delete.html
@@ -1,7 +1,21 @@
 {% extends '_base.html' %}
 {% block content %}
-<form method="post">{% csrf_token %}
-    <p>Are you sure you want to delete "{{ object }}"?</p>
-    <input type="submit" value="Confirm">
-</form>
+<div class='grid-row'>
+  <div class='grid-col-8 grid-offset-2'>
+    <form class="grid-col-12" method="post">{% csrf_token %}
+        <div class="usa-alert usa-alert--error">
+          <div class="usa-alert__body">
+              <h3 class="usa-alert__heading">Warning you cannot get this event back</h3>
+              <p class="usa-alert__text">Are you sure you want to delete "{{ object }}"?</p>
+          </div>
+        </div>
+        <br/>
+        <br/>
+        <div class="grid-col-4 grid-offset-4">
+          <input class="usa-button usa-button--outline" type="submit" value="Go Back">
+          <input class="usa-button usa-button--secondary" type="submit" value="Delete">
+        </div>
+    </form>
+  </div>
+</div>
 {% endblock %}

--- a/census/templates/census/pending_list.html
+++ b/census/templates/census/pending_list.html
@@ -1,7 +1,7 @@
 {% extends '_base.html' %}
 {% block content %}
 <div class='grid-row'>
-  <div class='grid-col-8 grid-offset-2'>
+  <div class='grid-col-10 grid-offset-1'>
     <h1 class='center-align'>Pending Events</h1>
     {% if event_list %}
       <table class="grid-col-12 usa-table usa-table--borderless">


### PR DESCRIPTION
Styling the Delete Event page and tweaked the table layout for the Review Events page

![image](https://user-images.githubusercontent.com/1768417/69208315-fe755380-0b07-11ea-8e36-245b7ae866f5.png)


Testing Steps.

1. Go to /pending
2. Click delete on one of the pending events
3. You should see the above page
    - if you hit go back it goes back to the review events page
    - if you hit delete it deletes the event
