### PR TITLE
Fix issue #56: Event detail page

### DIFF
--- a/census/google_calendar.py
+++ b/census/google_calendar.py
@@ -28,7 +28,10 @@ def google_publish_event(event):
     payload = {
       'summary': event.title,
       'location': event.location,
-      'description': event.description,
+      'description': event.description + "<a href=http://" +
+      # need to provide the right domain for the server
+      "localhost:8000" + "/event/" + str(event.id) +
+          "/details> Event Details</a>",
       'start': {
         'dateTime': event.start_datetime.isoformat(),
         'timeZone': settings.TIME_ZONE,

--- a/census/google_calendar.py
+++ b/census/google_calendar.py
@@ -4,6 +4,7 @@ import pickle
 import os.path
 
 from django.conf import settings
+from django.urls import reverse
 from googleapiclient.discovery import build
 from google.oauth2 import service_account
 
@@ -28,10 +29,10 @@ def google_publish_event(event):
     payload = {
       'summary': event.title,
       'location': event.location,
-      'description': event.description + "<a href=http://" +
-      # need to provide the right domain for the server
-      "localhost:8000" + "/event/" + str(event.id) +
-          "/details> Event Details</a>",
+      'description': event.description + "\n<a href=http://" +
+          settings.SITE_DOMAIN +
+          reverse('event_detail', args = [event.id]) +
+          "> Event Details</a>",
       'start': {
         'dateTime': event.start_datetime.isoformat(),
         'timeZone': settings.TIME_ZONE,

--- a/census/settings.py
+++ b/census/settings.py
@@ -27,6 +27,7 @@ env = environ.Env(
     LOG_LEVEL=(str, 'INFO'),
     DJANGO_LOG_LEVEL=(str, 'INFO'),
     TIME_ZONE=(str, 'America/Los_Angeles'),
+    SITE_DOMAIN=(str, 'localhost:8000'),
 )
 
 # Read additional environment variables from .env at the project root
@@ -42,6 +43,7 @@ SECRET_KEY = env('SECRET_KEY')
 DEBUG = env('DEBUG')
 
 ALLOWED_HOSTS = env('ALLOWED_HOSTS')
+SITE_DOMAIN = env('SITE_DOMAIN')
 
 
 # Application definition

--- a/census/settings.py
+++ b/census/settings.py
@@ -96,7 +96,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'census.wsgi.application'
 
-
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 DATABASES = {
@@ -188,3 +187,4 @@ STATIC_URL = '/static/'
 # https://warehouse.python.org/project/whitenoise/
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/'

--- a/census/static/datepicker/js/datepicker.js
+++ b/census/static/datepicker/js/datepicker.js
@@ -90,7 +90,9 @@ function render_events(events) {
                     "<button class='usa-accordion__button' aria-expanded='true' aria-controls='a" + events[month][j].id +
                     "'>" + events[month][j].title + priv + "</button>" + "</h2>"
                 var div = "<div id='a" + events[month][j].id + "' class='usa-accordion__content usa-prose'>" +
-                    "<p>" + events[month][j].description + "</p>" + "</div>";
+                  "<p>" + events[month][j].description + "</p>" +
+                  "<a href=/event/" + events[month][j].id + "/details> <b>Event Details</b></a>"
+                  "</div>";
                 $('#event-list').append(label);
                 $('#event-list').append(h2);
                 $('#event-list').append(div);

--- a/census/templates/census/event_form.html
+++ b/census/templates/census/event_form.html
@@ -11,11 +11,17 @@
         <section class='tablet:grid-col-8 tablet:grid-offset-2 section-card padding-x-4 padding-y-2 tablet:margin-4'>
 
             <form method="post" class="">
+
+            {% if form.is_private_event.value and not user.is_authenticated %}
+            <legend class="usa-legend">This Event is Private</legend>
+            {% else %}
                 <fieldset class="usa-fieldset">
                     {% if request.path == "/submit/" %}
                     <legend class="usa-legend">New Event</legend>
-                    {% else %}
+                    {% elif "/update/" in request.path  %}
                     <legend class="usa-legend">Edit Event</legend>
+                    {% else %}
+                    <legend class="usa-legend">Event Details</legend>
                     {% endif %}
                     {% csrf_token %}
                     {{ form.media }}
@@ -32,13 +38,14 @@
                     <div>
                       <label class="usa-label" for="{{ form.title.id_for_label }}">{{form.title.label}}:</label>
                       <span class="usa-hint line-height-body-1 font-body-2xs">{{form.title.help_text}}</span>
-                      <input type="text" name="{{ form.title.name }}" maxlength="100" class="usa-input" required="" id="{{ form.title.id_for_label }}" value="{{ form.title.value|default_if_none:'' }}">
+                      <input {{ readonly }} type="text" name="{{ form.title.name }}" maxlength="100" class="usa-input" required="" id="{{ form.title.id_for_label }}" value="{{ form.title.value|default_if_none:'' }}">
                     </div>
                     <div>
                       <label class="usa-label" for="{{ form.description.id_for_label }}">{{ form.description.label }}:</label>
                       <span class="usa-hint line-height-body-1 font-body-2xs">{{form.description.help_text}}</span>
-                      <textarea name="{{ form.description.name }}" cols="40" rows="10" class="usa-textarea" id="{{ form.description.id_for_label }}">{{form.description.value|default_if_none:''}}</textarea>
+                      <textarea {{ readonly }} name="{{ form.description.name }}" cols="40" rows="10" class="usa-textarea" id="{{ form.description.id_for_label }}">{{form.description.value|default_if_none:''}}</textarea>
                     </div>
+                    {% if readonly != 'readonly' or form.is_private_event.value %}
                     <div class="checkbox-wrapper">
                         <div class="usa-label grid-col-12">{{form.is_private_event.label}}:</div>
                         <div class="usa-hint font-body-2xs margin-y-1">{{form.is_private_event.help_text}}</div>
@@ -56,45 +63,47 @@
                           <label class="usa-checkbox__label" for="{{form.is_private_event.id_for_label}}">Is This Event Private?</label>
                         </div>
                     </div>
+                    {% endif %}
                     <div>
                         <label class="usa-label" for="{{form.organization_name.id_for_label}}">{{form.organization_name.label}}:</label>
                         <span class="usa-hint line-height-body-1 font-body-2xs">{{form.organization_name.help_text}}</span>
-                        <input type="text" name="{{ form.organization_name.name }}" maxlength="100" class="usa-input" required="" id="{{form.organization_name.id_for_label}}" value="{{form.organization_name.value|default_if_none:''}}">
-                    </div>  
+                        <input {{ readonly }} type="text" name="{{ form.organization_name.name }}" maxlength="100" class="usa-input" required="" id="{{form.organization_name.id_for_label}}" value="{{form.organization_name.value|default_if_none:''}}">
+                    </div>
                     <div>
                       <label class="usa-label" for="{{form.location.id_for_label}}">Location:</label>
                       <span class="usa-hint line-height-body-1 font-body-2xs">{{form.location.help_text}}</span>
-                      <input type="text" name="{{ form.location.name }}" maxlength="100" class="usa-input" required="" id="{{form.location.id_for_label}}" value="{{form.location.value|default_if_none:''}}">
+                      <input {{ readonly }} type="text" name="{{ form.location.name }}" maxlength="100" class="usa-input" required="" id="{{form.location.id_for_label}}" value="{{form.location.value|default_if_none:''}}">
                     </div>
                     <div>
-                      <label class="usa-label" for="{{ form.contact_name.id_for_label }}">{{form.contact_name.label}}:</label>  
-                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_name.help_text}}</span>            
-                      <input type="text" name="{{ form.contact_name.name }}" maxlength="100" class="usa-input" required="" id="{{ form.contact_name.id_for_label }}"  value="{{form.contact_name.value|default_if_none:''}}">  
+                      <label class="usa-label" for="{{ form.contact_name.id_for_label }}">{{form.contact_name.label}}:</label>
+                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_name.help_text}}</span>
+                      <input {{ readonly }} type="text" name="{{ form.contact_name.name }}" maxlength="100" class="usa-input" required="" id="{{ form.contact_name.id_for_label }}"  value="{{form.contact_name.value|default_if_none:''}}">
                     </div>
                     <div>
-                      <label class="usa-label" for="{{ form.contact_email.id_for_label }}">{{form.contact_email.label}}:</label>  
-                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_email.help_text}}</span>            
-                      <input type="email" name="{{ form.contact_email.name }}" maxlength="100" class="usa-input" required="" id="{{ form.contact_email.id_for_label }}" value="{{form.contact_email.value|default_if_none:''}}">
+                      <label class="usa-label" for="{{ form.contact_email.id_for_label }}">{{form.contact_email.label}}:</label>
+                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_email.help_text}}</span>
+                      <input {{ readonly }} type="email" name="{{ form.contact_email.name }}" maxlength="100" class="usa-input" required="" id="{{ form.contact_email.id_for_label }}" value="{{form.contact_email.value|default_if_none:''}}">
                     </div>
                     <div>
-                      <label class="usa-label" for="{{ form.contact_phone.id_for_label }}">{{form.contact_phone.label}}:</label>  
-                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_phone.help_text}}</span>            
-                      <input type="tel" name="{{ form.contact_phone.name }}" maxlength="100" class="usa-input" required="" id="{{ form.contact_phone.id_for_label }}" value="{{form.contact_phone.value|default_if_none:''}}">
+                      <label class="usa-label" for="{{ form.contact_phone.id_for_label }}">{{form.contact_phone.label}}:</label>
+                      <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_phone.help_text}}</span>
+                      <input {{ readonly }} type="tel" name="{{ form.contact_phone.name }}" maxlength="100" class="usa-input" required="" id="{{ form.contact_phone.id_for_label }}" value="{{form.contact_phone.value|default_if_none:''}}">
                     </div>
                     <div>
                       <label class="usa-label" for="{{form.event_type.id_for_label}}">{{form.fields.event_type.label}}:</label>
-                      <select name="{{form.event_type.name}}" class="usa-input desktop:grid-col-3 grid-col-6" required="" id="{{form.event_type.id_for_label}}">
+                      <select {{ readonly }} name="{{form.event_type.name}}" class="usa-input {{ readonly }} desktop:grid-col-3 grid-col-6" required="" id="{{form.event_type.id_for_label}}">
                           {% for value, display in form.fields.event_type.choices %}
-                            <option value="{{ value }}" {% if form.event_type.value == value %}selected{% endif %}>{{ display }}</option>
+                          <option {{ readonly }} value="{{ value }}" {% if form.event_type.value == value %}selected {{ readonly }}{% endif %}>{{ display }}</option>
                           {% endfor %}
                       </select>
                     </div>
+                    {% if readonly != 'readonly' or form.is_census_equipped.value %}
                     <div class="checkbox-wrapper">
                         <div class="usa-label grid-col-12">{{form.is_census_equipped.label}}:</div>
                         <div class="usa-hint font-body-2xs margin-y-1">{{form.is_census_equipped.help_text}}</div>
                         <div class="usa-checkbox">
-                          <input 
-                            class="usa-checkbox__input" 
+                          <input {{ readonly }}
+                            class="usa-checkbox__input"
                             id="{{form.is_census_equipped.id_for_label}}"
                             type="checkbox"
                             name="{{form.is_census_equipped.name}}"
@@ -106,9 +115,11 @@
                           <label class="usa-checkbox__label" for="{{form.is_census_equipped.id_for_label}}">Is census equipped?</label>
                         </div>
                     </div>
+                    {% endif %}
                     <div class="checkbox-wrapper grid-row">
                         <div class="usa-label grid-col-12 margin-bottom-2">{{form.languages.help_text}}</div>
                         {% for value, name in form.languages.field.choices %}
+                        {% if readonly != 'readonly' or value in form.languages.value %}
                         <div class="usa-checkbox grid-col-6">
                             <input
                               class="usa-checkbox__input"
@@ -122,18 +133,19 @@
                               >
                               <label class="usa-checkbox__label" for="{{form.languages.id_for_label}}_{{ forloop.counter }}">{{ name }}</label>
                         </div>
-                        {% endfor %} 
+                        {% endif %}
+                        {% endfor %}
                     </div>
                     <div class="grid-row">
                       <div class="desktop:grid-col-6">
                           <label class="usa-label" for="{{form.start_datetime.id_for_label}}">{{form.start_datetime.label}}:</label>
                           <div class="usa-hint line-height-body-1 font-body-2xs">{{form.start_datetime.help_text}}</div>
-                          <input class="usa-input grid-col-6" type="text" name="{{form.start_datetime.name}}" required="" id="{{form.start_datetime.id_for_label}}" value="{{form.start_datetime.value| date:'Y-m-d H:i'}}">
+                          <input {{ readonly }} class="usa-input grid-col-6" type="text" name="{{form.start_datetime.name}}" required="" id="{{form.start_datetime.id_for_label}}" value="{{form.start_datetime.value| date:'Y-m-d H:i'}}">
                       </div>
                       <div class="desktop:grid-col-6">
                           <label class="usa-label" for="{{form.end_datetime.id_for_label}}">{{form.end_datetime.label}}:</label>
                           <div class="usa-hint line-height-body-1 font-body-2xs">{{form.end_datetime.help_text}}</div>
-                          <input class="usa-input grid-col-6" type="text" name="{{form.end_datetime.name}}" required="" id="{{form.end_datetime.id_for_label}}" value="{{form.end_datetime.value| date:'Y-m-d H:i'}}">
+                          <input {{ readonly }} class="usa-input grid-col-6" type="text" name="{{form.end_datetime.name}}" required="" id="{{form.end_datetime.id_for_label}}" value="{{form.end_datetime.value| date:'Y-m-d H:i'}}">
                       </div>
                     </div>
                     {% if enable_recurrence %}
@@ -142,23 +154,26 @@
                         {{ form.recurrences }}
                     </div>
                     {% else %}
-                    <input type="hidden" name="{{ form.recurrences.name }}" value="" />
+                    <input {{ readonly }} type="hidden" name="{{ form.recurrences.name }}" value="" />
                     {% endif %}
 
-                    {% if request.path != "/submit/" %}
+                    {% if "/update/" in request.path  %}
                     <div>
                         <label class="usa-label" for="{{form.approval_status.id_for_label}}">{{form.approval_status.label}}:</label>
-                        <select name="{{form.approval_status.name}}" class="usa-input desktop:grid-col-3 grid-col-6" required="" id="{{form.approval_status.id_for_label}}">
+                        <select name="{{form.approval_status.name}}" class="usa-input {{ readonly }} desktop:grid-col-3 grid-col-6" required="" id="{{form.approval_status.id_for_label}}">
                             {% for value, display in form.fields.approval_status.choices %}
-                              <option value="{{ value }}" {% if form.approval_status.value == value %}selected{% endif %}>{{ display }}</option>
+                              <option {{ readonly }} value="{{ value }}" {% if form.approval_status.value == value %}selected{% endif %}>{{ display }}</option>
                             {% endfor %}
                         </select>
                     </div>
                     {% endif %}
 
                     </br>
+                    {% if  readonly != 'readonly' %}
                     <input type="submit" value="Submit" class="usa-button">
+                    {% endif %}
                 </fieldset>
+            {% endif %}
             </form>
         </section>
     </div>

--- a/census/templates/census/event_form.html
+++ b/census/templates/census/event_form.html
@@ -56,9 +56,8 @@
                             type="checkbox"
                             name="{{form.is_private_event.name}}"
                             value="is_private_event"
-                            {% if form.is_private_event.value %}
-                            checked="checked"
-                            {% endif %}
+                            {% if form.is_private_event.value %}checked="checked"{% endif %}
+                            {% if readonly %}disabled=""{% endif %}
                             >
                           <label class="usa-checkbox__label" for="{{form.is_private_event.id_for_label}}">Is This Event Private?</label>
                         </div>
@@ -113,9 +112,8 @@
                             type="checkbox"
                             name="{{form.is_census_equipped.name}}"
                             value="is_census_equipped"
-                            {% if form.is_census_equipped.value %}
-                            checked="checked"
-                            {% endif %}
+                            {% if form.is_census_equipped.value %}checked="checked"{% endif %}
+                            {% if readonly %}disabled=""{% endif %}
                             >
                           <label class="usa-checkbox__label" for="{{form.is_census_equipped.id_for_label}}">Is census equipped?</label>
                         </div>

--- a/census/templates/census/event_form.html
+++ b/census/templates/census/event_form.html
@@ -91,7 +91,12 @@
                     </div>
                     <div>
                       <label class="usa-label" for="{{form.event_type.id_for_label}}">{{form.fields.event_type.label}}:</label>
-                      <select {{ readonly }} name="{{form.event_type.name}}" class="usa-input {{ readonly }} desktop:grid-col-3 grid-col-6" required="" id="{{form.event_type.id_for_label}}">
+                      <select
+                        {% if readonly %} disabled="" {% endif %}
+                        name="{{form.event_type.name}}"
+                        class="usa-input {{ readonly }} desktop:grid-col-3 grid-col-6"
+                        required=""
+                        id="{{form.event_type.id_for_label}}">
                           {% for value, display in form.fields.event_type.choices %}
                           <option {{ readonly }} value="{{ value }}" {% if form.event_type.value == value %}selected {{ readonly }}{% endif %}>{{ display }}</option>
                           {% endfor %}
@@ -102,7 +107,7 @@
                         <div class="usa-label grid-col-12">{{form.is_census_equipped.label}}:</div>
                         <div class="usa-hint font-body-2xs margin-y-1">{{form.is_census_equipped.help_text}}</div>
                         <div class="usa-checkbox">
-                          <input {{ readonly }}
+                          <input
                             class="usa-checkbox__input"
                             id="{{form.is_census_equipped.id_for_label}}"
                             type="checkbox"
@@ -130,6 +135,7 @@
                               {% if value in form.languages.value %}
                               checked="checked"
                               {% endif %}
+                              {% if readonly %}disabled=""{% endif %}
                               >
                               <label class="usa-checkbox__label" for="{{form.languages.id_for_label}}_{{ forloop.counter }}">{{ name }}</label>
                         </div>
@@ -160,9 +166,18 @@
                     {% if "/update/" in request.path  %}
                     <div>
                         <label class="usa-label" for="{{form.approval_status.id_for_label}}">{{form.approval_status.label}}:</label>
-                        <select name="{{form.approval_status.name}}" class="usa-input {{ readonly }} desktop:grid-col-3 grid-col-6" required="" id="{{form.approval_status.id_for_label}}">
+                        <select
+                          name="{{form.approval_status.name}}"
+                          class="usa-input desktop:grid-col-3 grid-col-6"
+                          required=""
+                          id="{{form.approval_status.id_for_label}}">
                             {% for value, display in form.fields.approval_status.choices %}
-                              <option {{ readonly }} value="{{ value }}" {% if form.approval_status.value == value %}selected{% endif %}>{{ display }}</option>
+                              <option 
+                                value="{{ value }}"
+                                {% if form.approval_status.value == value %}selected=""{% endif %}
+                                >
+                                  {{ display }}
+                              </option>
                             {% endfor %}
                         </select>
                     </div>

--- a/census/templates/census/event_form.html
+++ b/census/templates/census/event_form.html
@@ -6,6 +6,11 @@
 <script type="text/javascript" src="/static/admin/js/jquery.init.js"></script>
 <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 
+<style>
+.usa-checkbox__input:disabled+.usa-checkbox__label {
+    color: #000000;
+}
+</style>
 <div class="grid-container">
     <div class="grid-row">
         <section class='tablet:grid-col-8 tablet:grid-offset-2 section-card padding-x-4 padding-y-2 tablet:margin-4'>

--- a/census/templates/includes/_nav.html
+++ b/census/templates/includes/_nav.html
@@ -6,7 +6,9 @@
     <div
       class="height-10 tablet:grid-col-12 bg-white border-bottom-05 border-gray-30"
     >
-      <img class="height-9" src="/static/census/img/main-logo-sm-2x.png" />
+      <a href="/">
+        <img class="height-9" src="/static/census/img/main-logo-sm-2x.png" />
+      </a>
     </div>
   </div>
   <div class="usa-nav-container">
@@ -27,6 +29,11 @@
         <li class="usa-nav__primary-item">
           <a class="usa-nav__link" href="/pending">
             <span>Review Events</span>
+          </a>
+        </li>
+        <li class="usa-nav__primary-item">
+          <a class="usa-nav__link" href="/approved">
+            <span>Update Approved Events</span>
           </a>
         </li>
         <li class="usa-nav__primary-item">

--- a/census/tests/test_google_publish.py
+++ b/census/tests/test_google_publish.py
@@ -71,7 +71,7 @@ class GoogleCalendarPublishEvent(TestCase):
         payload = self.mock_events.insert.call_args[1]['body']
 
         self.assertEqual(payload['summary'], event.title)
-        self.assertEqual(payload['description'], event.description)
+        self.assertTrue(payload['description'].startswith(event.description))
         self.assertEqual(payload['start']['dateTime'], event.start_datetime.isoformat())
         self.assertEqual(payload['start']['timeZone'], 'America/Los_Angeles')
         self.assertEqual(payload['end']['dateTime'], event.end_datetime.isoformat())

--- a/census/urls.py
+++ b/census/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     path('approved/', views.ApprovedList.as_view(), name = 'approved_list'),
     path('event/<int:pk>/update/', views.UpdateEvent.as_view(), name= 'event_update'),
     path('event/<int:pk>/delete/', views.DeleteEvent.as_view(), name= 'event_delete'),
+    path('event/<int:pk>/details/', views.ShowEvent.as_view(), name= 'event_detail'),
     url(r'^login/$', auth_views.LoginView.as_view(), name='login'),
     url(r'^logout/$', auth_views.LogoutView.as_view(), name='logout'),
     # this is to update list of events on the homepage based on datepicker selection

--- a/census/views.py
+++ b/census/views.py
@@ -237,12 +237,10 @@ class ApprovedList(ListView):
 
 class DeleteEvent(LoginRequiredMixin, DeleteView):
     model = models.Event
-    success_url = "/pending"
     login_url = '/login/'
     # Override the delete method so we can delete for the google calendar
     def delete(self, request, *args, **kwargs):
         self.object = event = self.get_object()
-        success_url = self.get_success_url()
         google_delete_event(event)
         event.delete()
         # Return to the list we came from.
@@ -251,3 +249,12 @@ class DeleteEvent(LoginRequiredMixin, DeleteView):
         else:
             return HttpResponseRedirect("/pending")
 
+class ShowEvent(UpdateView):
+    model = models.Event
+    form_class = EditEventForm
+    template_name = 'census/event_form.html'
+    def get_context_data(self, **kwargs):
+        # Call the base implementation first to get a context
+        context = super().get_context_data(**kwargs)
+        context['readonly'] = 'readonly'
+        return context


### PR DESCRIPTION
This adds the Event Detail page and puts a link to it in the calendar listings both on the home page and in google calendar.  Must be logged in to see private events.
**Needs to have code to put the actual server domain in the URL**
**Needs a way to make click boxes and dropdowns readonly**

Also added:
link to edit approved events
Link to home page in logo
Logout now goes to home page