### PR TITLE
Add copy event page

### DIFF
--- a/census/templates/census/approved_list.html
+++ b/census/templates/census/approved_list.html
@@ -15,6 +15,7 @@
             <th scope="col">Repeats</th>
             <th></th>
             <th></th>
+            <th></th>
           </tr>
         </thead>
         {% for event in event_list %}
@@ -37,6 +38,9 @@
                 </td>
                 <td>
                   <a class="usa-button usa-button--secondary" href="/event/{{ event.id }}/delete">DELETE</a>
+                </td>
+                <td>
+                  <a class="usa-button" href="/event/{{ event.id }}/copy">Copy</a>
                 </td>
             </tr>
           </tbody>

--- a/census/templates/census/copy_event.html
+++ b/census/templates/census/copy_event.html
@@ -1,0 +1,174 @@
+{% extends '_base.html' %}
+
+{% block content %}
+
+<script type="text/javascript" src="/static/admin/js/vendor/jquery/jquery.js"></script>
+<script type="text/javascript" src="/static/admin/js/jquery.init.js"></script>
+<script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
+
+<style>
+.usa-checkbox__input:disabled+.usa-checkbox__label {
+    color: #000000;
+}
+</style>
+<div class="grid-container">
+
+    <div class="grid-row">
+        <section class='tablet:grid-col-8 tablet:grid-offset-2 section-card padding-x-4 padding-y-2 tablet:margin-4'>
+
+            <form method="post" class="">
+                <fieldset class="usa-fieldset">
+                    <legend class="usa-legend">Copy Event</legend>
+                    {% csrf_token %}
+                    {{ form.media }}
+
+                    {% include 'includes/_form_errors.html' %}
+                    {% if message %}
+                      <div class="usa-alert usa-alert--success" role="alert">
+                          <div class="usa-alert__body">
+                            <h3 class="usa-alert__heading">{{message}}</h3>
+                            <p class="usa-alert__text"> It is now pending approval.</p>
+                          </div>
+                      </div>
+                    {% endif %}
+                    <div>
+                      <label class="usa-label">Copying event: {{form.title.value}}</label>
+                    </div>
+                    <div>
+                    <div>
+                        <label class="usa-label" for="{{ form.title.id_for_label }}">{{form.title.label}}:</label>
+                        <span class="usa-hint line-height-body-1 font-body-2xs">{{form.title.help_text}}</span>
+                        <input {{ readonly }} type="text" name="{{ form.title.name }}" maxlength="100" class="usa-input" required="" id="{{ form.title.id_for_label }}" value="{{ form.title.value|default_if_none:'' }}">
+                    </div>
+                    <div>
+                        <label class="usa-label" for="{{ form.description.id_for_label }}">{{ form.description.label }}:</label>
+                        <span class="usa-hint line-height-body-1 font-body-2xs">{{form.description.help_text}}</span>
+                        <textarea {{ readonly }} name="{{ form.description.name }}" cols="40" rows="10" class="usa-textarea" id="{{ form.description.id_for_label }}">{{form.description.value|default_if_none:''}}</textarea>
+                    </div>
+                    <div class="checkbox-wrapper">
+                        <div class="usa-label grid-col-12">{{form.is_private_event.label}}:</div>
+                        <div class="usa-hint font-body-2xs margin-y-1">{{form.is_private_event.help_text}}</div>
+                        <div class="usa-checkbox">
+                          <input 
+                            class="usa-checkbox__input" 
+                            id="{{form.is_private_event.id_for_label}}"
+                            type="checkbox"
+                            name="{{form.is_private_event.name}}"
+                            value="is_private_event"
+                            {% if form.is_private_event.value %}checked="checked"{% endif %}
+                            >
+                          <label class="usa-checkbox__label" for="{{form.is_private_event.id_for_label}}">Is This Event Private?</label>
+                        </div>
+                    </div>
+                    
+                    <input type="hidden" name="{{ form.organization_name.name }}" id="{{form.organization_name.id_for_label}}" value="{{ form.organization_name.value|default_if_none:'' }}">
+                    <input type="hidden" name="{{ form.location.name }}" id="{{form.location.id_for_label}}" value="{{ form.location.value|default_if_none:'' }}">
+                    <input type="hidden" name="{{ form.site_name.name }}" id="{{form.site_name.id_for_label}}" value="{{ form.site_name.value|default_if_none:'' }}">
+                    <input type="hidden" name="{{ form.lat.name }}" id="{{ form.lat.id_for_label }}" value="{{ form.lat.value|default_if_none:'' }}" />
+                    <input type="hidden" name="{{ form.lon.name }}" id="{{ form.lon.id_for_label }}" value="{{ form.lon.value|default_if_none:'' }}" />
+                    <input type="hidden" name="{{ form.city.name }}" id="{{ form.city.id_for_label }}" value="{{ form.city.value|default_if_none:'' }}">
+                    <input type="hidden" name="{{ form.zip_code.name }}" id="{{ form.zip_code.id_for_label }}" value="{{ form.zip_code.value|default_if_none:'' }}">
+
+                    <div>
+                        <label class="usa-label" for="{{ form.contact_name.id_for_label }}">{{form.contact_name.label}} (optional):</label>
+                        <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_name.help_text}}</span>
+                        <input type="text" name="{{ form.contact_name.name }}" maxlength="100" class="usa-input" id="{{ form.contact_name.id_for_label }}" value="{{ form.contact_name.value|default_if_none:'' }}">
+                    </div>
+                    <div>
+                        <label class="usa-label" for="{{ form.contact_email.id_for_label }}">{{form.contact_email.label}} (optional):</label>
+                        <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_email.help_text}}</span>
+                        <input type="email" name="{{ form.contact_email.name }}" maxlength="100" class="usa-input" id="{{ form.contact_email.id_for_label }}" value="{{ form.contact_email.value|default_if_none:'' }}">
+                    </div>
+                    <div>
+                        <label class="usa-label" for="{{ form.contact_phone.id_for_label }}">{{form.contact_phone.label}} (optional):</label>
+                        <span class="usa-hint line-height-body-1 font-body-2xs">{{form.contact_phone.help_text}}</span>
+                        <input type="tel" name="{{ form.contact_phone.name }}" maxlength="100" class="usa-input" id="{{ form.contact_phone.id_for_label }}" value="{{form.contact_phone.value|default_if_none:'' }}">
+                    </div>
+                    <div>
+                        <label class="usa-label" for="{{form.event_type.id_for_label}}">{{form.fields.event_type.label}}:</label>
+                        <select
+                            name="{{form.event_type.name}}"
+                            class="usa-input"
+                            required=""
+                            id="{{form.event_type.id_for_label}}">
+                            {% for value, display in form.fields.event_type.choices %}
+                                <option value="{{ value }}" {% if form.event_type.value == value %}selected {% endif %}>{{ display }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="checkbox-wrapper">
+                        <div class="usa-label grid-col-12">{{form.is_census_equipped.label}}:</div>
+                        <div class="usa-hint font-body-2xs margin-y-1">{{form.is_census_equipped.help_text}}</div>
+                        <div class="usa-checkbox">
+                            <input
+                                class="usa-checkbox__input"
+                                id="{{form.is_census_equipped.id_for_label}}"
+                                type="checkbox"
+                                name="{{form.is_census_equipped.name}}"
+                                value="is_census_equipped"
+                                {% if form.is_census_equipped.value %}checked="checked"{% endif %}
+                                >
+                            <label class="usa-checkbox__label" for="{{form.is_census_equipped.id_for_label}}">Is census equipped?</label>
+                        </div>
+                    </div>
+                    <div class="checkbox-wrapper">
+                        <div class="usa-label grid-col-12">{{form.is_ada_compliant.label}}:</div>
+                        <div class="usa-hint font-body-2xs margin-y-1">{{form.is_ada_compliant.help_text}}</div>
+                        <div class="usa-checkbox">
+                            <input
+                                class="usa-checkbox__input"
+                                id="{{form.is_ada_compliant.id_for_label}}"
+                                type="checkbox"
+                                name="{{form.is_ada_compliant.name}}"
+                                value="is_ada_compliant"
+                                {% if form.is_ada_compliant.value %}checked="checked"{% endif %}
+                                >
+                            <label class="usa-checkbox__label" for="{{form.is_ada_compliant.id_for_label}}">Is ADA compliant?</label>
+                        </div>
+                    </div>
+
+                    <div class="checkbox-wrapper grid-row">
+                        <div class="usa-label grid-col-12 margin-bottom-2">{{form.languages.help_text}}</div>
+                            {% for value, name in form.languages.field.choices %}
+                            <div class="usa-checkbox grid-col-6">
+                                <input
+                                class="usa-checkbox__input"
+                                id="{{form.languages.id_for_label}}_{{ forloop.counter }}"
+                                type="checkbox"
+                                name="{{ form.languages.name }}"
+                                value="{{ value }}"
+                                {% if value in form.languages.value %}
+                                checked="checked"
+                                {% endif %}
+                                {% if readonly %}disabled=""{% endif %}
+                                >
+                                <label class="usa-checkbox__label" for="{{form.languages.id_for_label}}_{{ forloop.counter }}">{{ name }}</label>
+                            </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="grid-row">
+                      <div class="desktop:grid-col-6">
+                          <label class="usa-label" for="{{form.start_datetime.id_for_label}}">New {{form.start_datetime.label}}:</label>
+                          <div class="usa-hint line-height-body-1 font-body-2xs">{{form.start_datetime.help_text}}</div>
+                          <input class="usa-input grid-col-6" type="text" name="{{form.start_datetime.name}}" required="" id="{{form.start_datetime.id_for_label}}" value="{{form.start_datetime.value| date:'Y-m-d H:i'}}">
+                      </div>
+                      <div class="desktop:grid-col-6">
+                          <label class="usa-label" for="{{form.end_datetime.id_for_label}}">New {{form.end_datetime.label}}:</label>
+                          <div class="usa-hint line-height-body-1 font-body-2xs">{{form.end_datetime.help_text}}</div>
+                          <input class="usa-input grid-col-6" type="text" name="{{form.end_datetime.name}}" required="" id="{{form.end_datetime.id_for_label}}" value="{{form.end_datetime.value| date:'Y-m-d H:i'}}">
+                      </div>
+                    </div>
+                    <input type="hidden" name="{{ form.recurrences.name }}" value="" />
+                    </br>
+                    <input type="submit" value="Submit" class="usa-button">
+                </fieldset>
+            </form>
+        </section>
+    </div>
+</div>
+
+<script src="https://maps.googleapis.com/maps/api/js?key={{google_maps_api_key}}&libraries=places&callback=initAutocomplete" async defer></script>
+{% endblock content %}
+{% block media %}
+{% endblock media %}

--- a/census/urls.py
+++ b/census/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('pending/', views.PendingList.as_view(), name = 'pending_list'),
     path('approved/', views.ApprovedList.as_view(), name = 'approved_list'),
     path('event/<int:pk>/update/', views.UpdateEvent.as_view(), name= 'event_update'),
+    path('event/<int:pk>/copy/', views.CopyEvent.as_view(), name= 'event_copy'),
     path('event/<int:pk>/delete/', views.DeleteEvent.as_view(), name= 'event_delete'),
     path('event/<int:pk>/details/', views.ShowEvent.as_view(), name= 'event_detail'),
     url(r'^login/$', auth_views.LoginView.as_view(), name='login'),


### PR DESCRIPTION
On the list of approved events, there is now a "Copy" button for each
event, which links to the copy page. The page contains a form with all
fields filled out from the existing event. All fields except for location
fields are editable. The reasoning for this is that copying an event
will be another occance of a very similar event in the same location.
On submit, the event is created as pending, just like a newly created
event.