### PR TITLE
Add location to event overview

### DIFF
--- a/census/templates/index.html
+++ b/census/templates/index.html
@@ -59,9 +59,12 @@
                                     <button class="usa-accordion__button"
                                             aria-expanded="true"
                                             aria-controls="a{{ event.id }}">
-                                        <span>{{ event.start_time }} - {{ event.end_time }}</span>
-                                        <span class="text-normal">
-                                            {{ event.title }}
+                                        <span style="line-height: 1.5;">{{ event.title }}</span>
+                                        <br />
+                                        <span class="text-normal" style="line-height: 1.2;">
+                                            {{ event.start_time }} - {{ event.end_time }}
+                                            <br />
+                                            {{ event.location }}
                                             {% if event.is_private_event %}
                                                 (PRIVATE)
                                             {% endif %}

--- a/census/views.py
+++ b/census/views.py
@@ -277,6 +277,7 @@ class HomepageView(View):
                     end_time=end_time,
                     city=event.city,
                     zip_code=event.zip_code,
+                    location=event.location,
                     )
 
 


### PR DESCRIPTION
The event overview is the what is displayed for each of the events on
the home page. Changed the event title (part in bold) to be the event
title instead of start - end times. Added the address location as a
new line. It is important to include the event location because it is
one of the main things people care about when considering going to an
event.